### PR TITLE
Implement Google Sign-In authentication and add sign-out functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@supabase/supabase-js": "^2.45.4",
         "@types/papaparse": "^5.3.14",
         "axios": "^1.7.7",
+        "jwt-decode": "^4.0.0",
         "papaparse": "^5.4.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -38,6 +39,9 @@
         "vite": "^5.4.1",
         "vite-plugin-top-level-await": "^1.4.4",
         "vite-plugin-wasm": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=19.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3691,6 +3695,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@supabase/supabase-js": "^2.45.4",
     "@types/papaparse": "^5.3.14",
     "axios": "^1.7.7",
+    "jwt-decode": "^4.0.0",
     "papaparse": "^5.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Login from './components/Login';
+import { User } from './types';
 import { 
   Container, 
   createTheme, 
@@ -17,7 +18,7 @@ const theme = createTheme({
 
 function App() {
 
-  const [user, setUser] = useState(null);
+  const [user, setUser] = useState<User | null>(null);
  
   useEffect(() => {
     const token = localStorage.getItem('token');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+import React, { useEffect, useState } from 'react';
+import Login from './components/Login';
 import { 
   Container, 
   createTheme, 
@@ -14,11 +16,25 @@ const theme = createTheme({
 });
 
 function App() {
+
+  const [user, setUser] = useState(null);
+ 
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      setUser({ loggedIn: true });
+    }
+  }, []); 
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Container maxWidth="md">
-        <SimulationWizard />
+        {user ? (
+          <SimulationWizard setUser={setUser} />
+        ) : (
+          <Login setUser={setUser} />
+        )}
       </Container>
     </ThemeProvider>
   );

--- a/src/components/GoogleSignIn.tsx
+++ b/src/components/GoogleSignIn.tsx
@@ -19,7 +19,7 @@ const GoogleSignIn: React.FC<GoogleSignInProps> = ({ onSuccess, onError }) => {
       variant="contained"
       color="primary"
     >
-      Sign in with Google.
+      Sign in with Google
     </Button>
   );
 };

--- a/src/components/GoogleSignIn.tsx
+++ b/src/components/GoogleSignIn.tsx
@@ -19,7 +19,7 @@ const GoogleSignIn: React.FC<GoogleSignInProps> = ({ onSuccess, onError }) => {
       variant="contained"
       color="primary"
     >
-      Sign in with Google
+      Sign in with Google.
     </Button>
   );
 };

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import GoogleSignIn from './GoogleSignIn';
+
+const Login = ({ setUser }) => {
+  const handleLoginSuccess = (credentialResponse: any) => {
+    const token = credentialResponse.access_token;
+    localStorage.setItem('token', token);
+    setUser({ loggedIn: true });
+  };
+
+  const handleLoginError = () => {
+    console.error('Login Failed');
+  };
+
+  return (
+    <div>
+      <h2>Login with Google.</h2>
+      <GoogleSignIn onSuccess={handleLoginSuccess} onError={handleLoginError} />
+    </div>
+  );
+};
+
+export default Login;

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import GoogleSignIn from './GoogleSignIn';
+import { User } from '../types';
 
-const Login = ({ setUser }) => {
+interface LoginProps {
+  setUser: React.Dispatch<React.SetStateAction<User | null>>;
+}
+
+const Login: React.FC<LoginProps> = ({ setUser }) => {
   const handleLoginSuccess = (credentialResponse: any) => {
     const token = credentialResponse.access_token;
     localStorage.setItem('token', token);

--- a/src/components/SimulationWizard.tsx
+++ b/src/components/SimulationWizard.tsx
@@ -19,7 +19,7 @@ import { initializeEncoder, estimateCost } from '../utils/tokenEstimation';
 import { ResponseData, ResponseType } from '../types';
 import { ModelType } from '../config';
 
-function SimulationWizard() {
+function SimulationWizard( {setUser }) {
   const [activeStep, setActiveStep] = useState(0);
   const [question, setQuestion] = useState('');
   const [responseTypes, setResponseTypes] = useState<string[]>([]);
@@ -53,6 +53,11 @@ function SimulationWizard() {
       setCostEstimation(null);
     }
   }, [encoderReady, question, responseTypes, hiveSize, model]);
+
+  const handleSignOut = () => {
+    localStorage.removeItem('token');
+    setUser(null);
+  };
 
   const handleSubmit = async () => {
     if (!question || responseTypes.length === 0) {
@@ -154,13 +159,18 @@ function SimulationWizard() {
       )}
       <Box mt={2} display="flex" justifyContent="space-between">
         {activeStep === steps.length - 1 ? (
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleNewQuestion}
-          >
-            New Question
-          </Button>
+          <>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleNewQuestion}
+            >
+              New Question
+            </Button>
+            <Button variant="outlined" color="secondary" onClick={handleSignOut}>
+              Sign Out
+            </Button>
+          </>
         ) : (
           <>
             <Button
@@ -183,6 +193,9 @@ function SimulationWizard() {
             >
               {loading ? <CircularProgress size={24} /> : 
                 activeStep === steps.length - 2 ? 'Submit' : 'Next'}
+            </Button>
+            <Button variant="outlined" color="secondary" onClick={handleSignOut}>
+              Sign Out
             </Button>
           </>
         )}

--- a/src/components/SimulationWizard.tsx
+++ b/src/components/SimulationWizard.tsx
@@ -19,7 +19,7 @@ import { initializeEncoder, estimateCost } from '../utils/tokenEstimation';
 import { ResponseData, ResponseType } from '../types';
 import { ModelType } from '../config';
 
-function SimulationWizard( {setUser }) {
+function SimulationWizard( { setUser }) {
   const [activeStep, setActiveStep] = useState(0);
   const [question, setQuestion] = useState('');
   const [responseTypes, setResponseTypes] = useState<string[]>([]);

--- a/src/components/SimulationWizard.tsx
+++ b/src/components/SimulationWizard.tsx
@@ -16,10 +16,14 @@ import ResultsDisplay from './ResultsDisplay';
 import { getResponses } from '../services/api';
 import { loadPerspectives } from '../services/perspectivesData';
 import { initializeEncoder, estimateCost } from '../utils/tokenEstimation';
-import { ResponseData, ResponseType } from '../types';
+import { ResponseData, ResponseType, User } from '../types';
 import { ModelType } from '../config';
 
-function SimulationWizard( { setUser }) {
+interface SimulationWizardProps {
+  setUser: React.Dispatch<React.SetStateAction<User | null>>;
+}
+
+function SimulationWizard({ setUser }: SimulationWizardProps) {
   const [activeStep, setActiveStep] = useState(0);
   const [question, setQuestion] = useState('');
   const [responseTypes, setResponseTypes] = useState<string[]>([]);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { GoogleOAuthProvider } from '@react-oauth/google';
 import App from './App.tsx'
 import { CssBaseline, ThemeProvider, createTheme } from '@mui/material'
 
@@ -9,7 +10,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <App />
+      <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+        <App />
+      </GoogleOAuthProvider>
     </ThemeProvider>
   </React.StrictMode>,
 )

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,3 +29,8 @@ export interface ResponseData {
     likert?: number;
   }>;
 }
+
+export interface User {
+  loggedIn: boolean;
+  email?: string;
+}


### PR DESCRIPTION
Dev notes:
    - Needs the Google client id in the .env file: VITE_GOOGLE_CLIENT_ID=<google client id>
    - There are new packages so run `npm install`

Storing the token using localStorage, which is different than cookies. It is the most convenient and long lasting, but there is a security vulnerability from cross site scripting attacks. Still, it seems this is a pretty common method.

- Added Google Sign-In using @react-oauth/google
- Created Login component
- Updated App.tsx for conditional rendering based on authentication state
- Added sign-out button in SimulationWizard
- Updated package.json and package-lock.json with new dependencies